### PR TITLE
[BE-012] Update ffmpeg service

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -13,7 +13,7 @@ export const INITIALSETTINGS = {
 		outputExtension: ".aac",
 		audioCodec: "copy",
 		audioQuality: "4",
-		audioFilter: "loudnorm",
+		audioFilter: "",
 		filterOptions: {},
 	},
 } satisfies GeneralSettings;

--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -10,9 +10,11 @@ export const INITIALSETTINGS = {
 		concurrency: 1,
 	},
 	audio: {
+		outputExtension: ".aac",
 		audioCodec: "copy",
 		audioQuality: "4",
 		audioFilter: "loudnorm",
+		filterOptions: {},
 	},
 } satisfies GeneralSettings;
 

--- a/src/main/lib/ffmpeg/buildFilter.ts
+++ b/src/main/lib/ffmpeg/buildFilter.ts
@@ -1,0 +1,11 @@
+export const buildFilter = (
+	filterName: string,
+	options: Record<string, string | number | boolean>,
+) => {
+	const optionsArray = Object.entries(options);
+	if (optionsArray.length > 0) {
+		const filterArgs = optionsArray.map(([k, v]) => `${k}=${v}`).join(":");
+		return ["-af", `${filterName}=${filterArgs}`];
+	}
+	return ["-af", `${filterName}`];
+};

--- a/src/main/lib/ffmpeg/getGlobalSettings.ts
+++ b/src/main/lib/ffmpeg/getGlobalSettings.ts
@@ -1,20 +1,13 @@
-import type { GeneralSettings, OptionMapperKeys } from "@/types";
+import type { GeneralSettings } from "@/types";
 
-export const getGlobalSettings = (
-	initialSettings: GeneralSettings,
-	settings: GeneralSettings["global"],
-	mapper: (option: OptionMapperKeys) => string,
-) => {
+export const getGlobalSettings = (settings: GeneralSettings["global"]) => {
 	const result: string[] = [];
-	for (const s in settings) {
-		const key = s as OptionMapperKeys;
-		if (
-			settings[key] !== initialSettings.global[key] &&
-			s !== "outputDirectoryPath" &&
-			s !== "concurrency"
-		) {
-			result.push(mapper(key));
-		}
+
+	if (settings.overwrite) {
+		result.push("-y");
+	}
+	if (settings.noOverwrite) {
+		result.push("-n");
 	}
 	return result;
 };

--- a/src/main/lib/ffmpeg/getTrackSettings.ts
+++ b/src/main/lib/ffmpeg/getTrackSettings.ts
@@ -1,15 +1,22 @@
-import type { GeneralSettings, OptionMapperKeys } from "@/types";
+import type { GeneralSettings } from "@/types";
+import { buildFilter } from "./buildFilter";
 
 export const getTrackSettings = (
-	initialSettings: GeneralSettings,
+	initialSettings: GeneralSettings["audio"],
 	settings: GeneralSettings["audio"],
-	mapper: (option: OptionMapperKeys) => string,
 ) => {
 	const result: string[] = [];
-	for (const s in settings) {
-		const key = s as OptionMapperKeys;
-		if (settings[key] !== initialSettings.audio[key]) {
-			result.push(`${mapper(key)} ${settings[key]}`);
+
+	if (settings.audioCodec !== initialSettings.audioCodec) {
+		result.push(`-codec:a ${settings.audioCodec}`);
+	}
+	if (settings.audioQuality !== initialSettings.audioQuality) {
+		result.push(`-q:a ${settings.audioQuality}`);
+	}
+	if (settings.audioFilter) {
+		const filter = buildFilter(settings.audioFilter, settings.filterOptions);
+		if (filter) {
+			result.push(...filter);
 		}
 	}
 	return result;

--- a/src/main/services/processing.service.ts
+++ b/src/main/services/processing.service.ts
@@ -1,10 +1,6 @@
 import path from "node:path";
 import { EVENT_CHANNELS, INITIALSETTINGS } from "@main/constants";
-import {
-	getGlobalSettings,
-	getTrackSettings,
-	optionsMapper,
-} from "@main/lib/ffmpeg";
+import { getGlobalSettings, getTrackSettings } from "@main/lib/ffmpeg";
 import { getTrackTitle, isDirectory } from "@main/lib/utils";
 import { ProcessManager } from "@main/services/ffmpeg/processManager";
 import type { IpcMainInvokeEvent } from "electron";
@@ -31,11 +27,7 @@ export const startProcessing = async (
 	const { signal } = abortController;
 	const queue = new PQueue({ concurrency: +data.settings.global.concurrency });
 
-	const globalSettings = getGlobalSettings(
-		INITIALSETTINGS,
-		data.settings.global,
-		optionsMapper,
-	);
+	const globalSettings = getGlobalSettings(data.settings.global);
 	const trackSettings = getTrackSettings(
 		INITIALSETTINGS.audio,
 		data.settings.audio,

--- a/src/main/services/processing.service.ts
+++ b/src/main/services/processing.service.ts
@@ -37,9 +37,8 @@ export const startProcessing = async (
 		optionsMapper,
 	);
 	const trackSettings = getTrackSettings(
-		INITIALSETTINGS,
+		INITIALSETTINGS.audio,
 		data.settings.audio,
-		optionsMapper,
 	);
 
 	for (const track of data.tracks) {


### PR DESCRIPTION
## Summary

This PR refactors the main process to simplify how global and audio settings are handled, and ensures the initial settings constants are consistent with the current settings types. It reduces dependencies, removes hard‑coded defaults, and introduces a utility to dynamically build FFmpeg filter arguments from the user‑selected filter options.

## Changes

### Refactors
- **Simplified getGlobalSettings**  
  Removed the dependency on INITIALSETTINGS and optionsMapper. The function now only handles the -y (overwrite) and -n (no overwrite) flags, extracting them directly from the settings object.

- **Dynamic audio filter argument generation**  
  Added a buildFilter utility that constructs FFmpeg -af filter strings from a filter name and its option values. 
  The default audio filter has been changed from "loudnorm" to an empty string (no filter applied by default).

- **Updated processing service**  
  The processing service now passes only the relevant settings objects to getGlobalSettings and getTrackSettings, aligning with the simplified function signatures.

### Features / Fixes
- **Added missing fields to INITIALSETTINGS**  
  outputExtension and filterOptions were added to the audio section of the initial settings constants, ensuring the main process default state matches the GeneralSettings type and is consistent with the renderer’s Redux slice.

## Notes
- No breaking changes for users; existing settings are preserved.
- The optionsMapper dependency has been completely removed from audio settings handling.
