### PR TITLE
refactor(settings): remove unused statsPeriod input from global options

### DIFF
--- a/src/renderer/src/components/Settings/GlobalOptions/GlobalOptions.tsx
+++ b/src/renderer/src/components/Settings/GlobalOptions/GlobalOptions.tsx
@@ -94,11 +94,6 @@ export function GlobalOptions({
 						{...form.getInputProps("global.noOverwrite", { type: "checkbox" })}
 					/>
 				</Stack>
-				<TextInput
-					label={"Set stats update interval in seconds:"}
-					key={form.key("global.statsPeriod")}
-					{...form.getInputProps("global.statsPeriod")}
-				/>
 			</Stack>
 		</Box>
 	);


### PR DESCRIPTION
The "statsPeriod" setting was not being used in the main process.