### PR TITLE
fix(settings): use structuredClone for deep cloning form values

### DIFF
--- a/src/renderer/src/components/Settings/hooks/useSettingsForm.ts
+++ b/src/renderer/src/components/Settings/hooks/useSettingsForm.ts
@@ -24,15 +24,15 @@ export default function useSettingsForm() {
 	const settings = useAppSelector((state) => state.settings);
 	const form = useForm<SettingsForm>({
 		initialValues: {
-			audio: { ...settings.audio },
-			global: { ...settings.global },
+			audio: structuredClone(settings.audio),
+			global: structuredClone(settings.global),
 		},
 	});
 
 	useEffect(() => {
 		form.setValues({
-			audio: { ...settings.audio },
-			global: { ...settings.global },
+			audio: structuredClone(settings.audio),
+			global: structuredClone(settings.global),
 		});
 	}, [form.setValues, settings]);
 


### PR DESCRIPTION
Replace shallow spread operator with structuredClone to properly copy nested objects (filterOptions, codecOptions) when initializing and updating the settings form.