### PR TITLE
fix(settings): specify checkbox type for Switch components in form binding

### DIFF
--- a/src/renderer/src/components/Settings/AudioOptions/Codecs/CodecOptions/CodecOptions.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Codecs/CodecOptions/CodecOptions.tsx
@@ -70,7 +70,9 @@ export function CodecOptions({
 									onLabel="enable"
 									offLabel="disable"
 									size="md"
-									{...form.getInputProps(`audio.codecOptions.${field.label}`)}
+									{...form.getInputProps(`audio.codecOptions.${field.label}`, {
+										type: "checkbox",
+									})}
 									styles={{
 										body: {
 											justifyContent: "space-between",

--- a/src/renderer/src/components/Settings/AudioOptions/Filters/FilterOptions/FilterOptions.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Filters/FilterOptions/FilterOptions.tsx
@@ -86,7 +86,9 @@ export function AudioFilterFactory({
 								onLabel="enable"
 								offLabel="disable"
 								size="md"
-								{...form.getInputProps(`audio.filterOptions.${field.label}`)}
+								{...form.getInputProps(`audio.filterOptions.${field.label}`, {
+									type: "checkbox",
+								})}
 								styles={{
 									body: {
 										justifyContent: "space-between",


### PR DESCRIPTION
Add { type: "checkbox" } to form.getInputProps for Switch fields in both CodecOptions and FilterOptions. This ensures Mantine's Switch correctly handles boolean values with the useForm hook.