### PR TITLE
fix(processing): reset isRunning state after processing completes

### DIFF
--- a/src/renderer/src/components/StartProcessing/StartProcessing.tsx
+++ b/src/renderer/src/components/StartProcessing/StartProcessing.tsx
@@ -61,6 +61,7 @@ export default function StartProcessing() {
 			const data: Data = { tracks, settings };
 			const results = await window.api.startProcessing(data);
 			dispatch(setResults(results));
+			setIsRunning(false);
 		}
 	};
 


### PR DESCRIPTION
Add setIsRunning(false) after dispatching processing results to ensure the UI correctly reflects that the processing has finished, preventing the run button from appearing stuck in a running state.