### PR TITLE
[FE-050] Add settings reset

### DIFF
--- a/src/renderer/src/components/Settings/AudioOptions/Codecs/Codecs.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Codecs/Codecs.tsx
@@ -44,6 +44,7 @@ export default function Codecs({
 					form.setFieldValue("audio.audioCodec", value);
 					form.setFieldValue("audio.codecOptions", {});
 				}}
+				clearable
 			/>
 			{activeCodec && <CodecOptions form={form} codec={activeCodec} />}
 		</Stack>

--- a/src/renderer/src/components/Settings/AudioOptions/Filters/Filters.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Filters/Filters.tsx
@@ -70,7 +70,7 @@ export default function Filters({
 		>
 			<Combobox.Target>
 				<TextInput
-					label="Pick an audio filter or type anything:"
+					label="Audio filter:"
 					value={search}
 					{...inputProps}
 					onChange={(e) => {
@@ -81,7 +81,15 @@ export default function Filters({
 					onClick={() => combobox.openDropdown()}
 					onFocus={() => combobox.openDropdown()}
 					onBlur={() => combobox.closeDropdown()}
-					rightSection={<Combobox.Chevron />}
+					rightSection={
+						search ? (
+							<Combobox.ClearButton
+								onClear={() => form.setFieldValue("audio.audioFilter", "")}
+							/>
+						) : (
+							<Combobox.Chevron />
+						)
+					}
 					key={form.key("audio.audioFilter")}
 				/>
 			</Combobox.Target>

--- a/src/renderer/src/components/Settings/Settings.tsx
+++ b/src/renderer/src/components/Settings/Settings.tsx
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Button, Loader, Modal, Stack } from "@mantine/core";
+import { Button, Flex, Loader, Modal, Stack } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { useAppDispatch } from "@renderer/hooks/useAppDispatch";
 import { saveSettings } from "@renderer/store/slices/settingsSlice";
@@ -51,9 +51,12 @@ export default function Settings() {
 					<Stack>
 						<GlobalOptions form={form} />
 						<AudioOptions form={form} />
-						<Button type="submit" mt={"lg"}>
-							Submit
-						</Button>
+						<Flex align={"center"} justify={"space-between"} mt={"sm"}>
+							<Button onClick={() => form.reset()}>Reset</Button>
+							<Button type="submit" bg="green" px={"xl"}>
+								Submit
+							</Button>
+						</Flex>
 					</Stack>
 				</form>
 			</Modal>


### PR DESCRIPTION
## Summary

This PR enhances the Settings page with better form controls and usability improvements. It adds a reset button, allows clearing the audio codec selection, and provides a clear button for the filter combobox. The submit button styling is also updated for better visual feedback.

## Changes

### Features & Enhancements
- **Reset button**  
  Added a “Reset” button next to the Submit button. It reverts all form fields to their initial values. Buttons are now arranged with space-between alignment in a Flex container.

- **Styled submit button**  
  The submit button now has a green background and horizontal padding, making it stand out and consistent with a successful save action.

- **Clearable audio codec select**  
  The audio codec Select component is now clearable. Users can remove the current codec selection and leave it empty (no codec explicitly set).

- **Clearable audio filter combobox**  
  The filter combobox label was simplified to “Audio filter:”.  
  A clear button appears when the input contains text, allowing users to reset the filter value. The chevron icon is only shown when the input is empty, reducing visual clutter.