### PR TITLE
refactor(settings): replace prop drilling with form context

### DIFF
--- a/src/renderer/src/components/Settings/AudioOptions/Bitrate/Bitrate.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Bitrate/Bitrate.tsx
@@ -16,14 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Flex, SegmentedControl, Text } from "@mantine/core";
-import type { UseFormReturnType } from "@mantine/form";
-import type { SettingsForm } from "@types";
+import { useSettingsFormContext } from "@renderer/components/Settings/context/SettingsFormContext";
 import BitrateOptions from "./BitrateOptions/BitrateOptions";
-export default function Bitrate({
-	form,
-}: {
-	form: UseFormReturnType<SettingsForm>;
-}) {
+
+export default function Bitrate() {
+	const form = useSettingsFormContext();
 	return (
 		<>
 			<Flex align={"center"} gap={"sm"}>
@@ -34,7 +31,7 @@ export default function Bitrate({
 					{...form.getInputProps("audio.audioQuality")}
 				/>
 			</Flex>
-			<BitrateOptions form={form} />
+			<BitrateOptions />
 		</>
 	);
 }

--- a/src/renderer/src/components/Settings/AudioOptions/Bitrate/BitrateOptions/BitrateOptions.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Bitrate/BitrateOptions/BitrateOptions.tsx
@@ -16,14 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Select, Slider, Text } from "@mantine/core";
-import type { UseFormReturnType } from "@mantine/form";
-import type { SettingsForm } from "@types";
+import { useSettingsFormContext } from "@renderer/components/Settings/context/SettingsFormContext";
 
-export default function BitrateOptions({
-	form,
-}: {
-	form: UseFormReturnType<SettingsForm>;
-}) {
+export default function BitrateOptions() {
+	const form = useSettingsFormContext();
 	const mode = form.getInputProps("audio.audioQuality").value;
 
 	switch (mode) {

--- a/src/renderer/src/components/Settings/AudioOptions/Codecs/CodecOptions/CodecOptions.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Codecs/CodecOptions/CodecOptions.tsx
@@ -16,17 +16,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { NumberInput, Select, Stack, Switch, Title } from "@mantine/core";
-import type { UseFormReturnType } from "@mantine/form";
+import { useSettingsFormContext } from "@renderer/components/Settings/context/SettingsFormContext";
 import { ENCODER_OPTIONS } from "@renderer/components/Settings/settings.constants";
-import type { AUDIO_ENCODER_NAMES, SettingsForm } from "@types";
+import type { AUDIO_ENCODER_NAMES } from "@types";
 
 export function CodecOptions({
-	form,
 	codec,
 }: {
-	form: UseFormReturnType<SettingsForm>;
 	codec: AUDIO_ENCODER_NAMES | "copy";
 }) {
+	const form = useSettingsFormContext();
 	if (codec !== "copy") {
 		const config = ENCODER_OPTIONS[codec];
 

--- a/src/renderer/src/components/Settings/AudioOptions/Codecs/Codecs.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Codecs/Codecs.tsx
@@ -17,9 +17,8 @@
  */
 
 import { Select, Stack } from "@mantine/core";
-import type { UseFormReturnType } from "@mantine/form";
+import { useSettingsFormContext } from "@renderer/components/Settings/context/SettingsFormContext";
 import { ENCODER_GROUPS } from "@renderer/components/Settings/settings.constants";
-import type { SettingsForm } from "@types";
 import { CodecOptions } from "./CodecOptions/CodecOptions";
 
 const data = ENCODER_GROUPS.map((item) => ({
@@ -27,11 +26,8 @@ const data = ENCODER_GROUPS.map((item) => ({
 	items: [...item.encoders],
 }));
 
-export default function Codecs({
-	form,
-}: {
-	form: UseFormReturnType<SettingsForm>;
-}) {
+export default function Codecs() {
+	const form = useSettingsFormContext();
 	const activeCodec = form.values.audio.audioCodec;
 
 	return (
@@ -46,7 +42,7 @@ export default function Codecs({
 				}}
 				clearable
 			/>
-			{activeCodec && <CodecOptions form={form} codec={activeCodec} />}
+			{activeCodec && <CodecOptions codec={activeCodec} />}
 		</Stack>
 	);
 }

--- a/src/renderer/src/components/Settings/AudioOptions/Filters/FilterOptions/FilterOptions.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Filters/FilterOptions/FilterOptions.tsx
@@ -23,18 +23,17 @@ import {
 	TextInput,
 	Title,
 } from "@mantine/core";
-import type { UseFormReturnType } from "@mantine/form";
+import { useSettingsFormContext } from "@renderer/components/Settings/context/SettingsFormContext";
 import { FILTER_OPTIONS } from "@renderer/components/Settings/settings.constants";
-import type { AUDIO_FILTER_NAMES, SettingsForm } from "@types";
+import type { AUDIO_FILTER_NAMES } from "@types";
 import type { JSX } from "react";
 
 export function AudioFilterFactory({
-	form,
 	filter,
 }: {
-	form: UseFormReturnType<SettingsForm>;
 	filter: AUDIO_FILTER_NAMES;
 }): JSX.Element {
+	const form = useSettingsFormContext();
 	const config = FILTER_OPTIONS[filter as keyof typeof FILTER_OPTIONS];
 
 	if (!config) return <div>Unknown filter</div>;

--- a/src/renderer/src/components/Settings/AudioOptions/Filters/Filters.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Filters/Filters.tsx
@@ -16,20 +16,17 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Combobox, TextInput, useCombobox } from "@mantine/core";
-import type { UseFormReturnType } from "@mantine/form";
 import { AudioFilterFactory } from "@renderer/components/Settings/AudioOptions/Filters/FilterOptions/FilterOptions";
+import { useSettingsFormContext } from "@renderer/components/Settings/context/SettingsFormContext";
 import { FILTER_OPTIONS } from "@renderer/components/Settings/settings.constants";
-import type { AUDIO_FILTER_NAMES, SettingsForm } from "@types";
+import type { AUDIO_FILTER_NAMES } from "@types";
 import { useMemo } from "react";
 
 // temp line
 const opts = Object.values(FILTER_OPTIONS);
 
-export default function Filters({
-	form,
-}: {
-	form: UseFormReturnType<SettingsForm>;
-}) {
+export default function Filters() {
+	const form = useSettingsFormContext();
 	const combobox = useCombobox({
 		onDropdownOpen: () => combobox.selectActiveOption(),
 		onDropdownClose: () => combobox.resetSelectedOption(),
@@ -99,7 +96,7 @@ export default function Filters({
 				</Combobox.Options>
 			</Combobox.Dropdown>
 			{exactMatch && search && (
-				<AudioFilterFactory form={form} filter={search as AUDIO_FILTER_NAMES} />
+				<AudioFilterFactory filter={search as AUDIO_FILTER_NAMES} />
 			)}
 		</Combobox>
 	);

--- a/src/renderer/src/components/Settings/AudioOptions/OutputExtensions/OutputExtensions.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/OutputExtensions/OutputExtensions.tsx
@@ -16,15 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { NativeSelect } from "@mantine/core";
-import type { UseFormReturnType } from "@mantine/form";
-import type { SettingsForm } from "@types";
+import { useSettingsFormContext } from "@renderer/components/Settings/context/SettingsFormContext";
 import { EXTENSIONS_LIST } from "../../settings.constants";
 
-export default function OutputExtensions({
-	form,
-}: {
-	form: UseFormReturnType<SettingsForm>;
-}) {
+export default function OutputExtensions() {
+	const form = useSettingsFormContext();
 	return (
 		<NativeSelect
 			label="Output file extension:"

--- a/src/renderer/src/components/Settings/GlobalOptions/GlobalOptions.tsx
+++ b/src/renderer/src/components/Settings/GlobalOptions/GlobalOptions.tsx
@@ -24,17 +24,13 @@ import {
 	TextInput,
 	Title,
 } from "@mantine/core";
-import type { UseFormReturnType } from "@mantine/form";
+import { useSettingsFormContext } from "@renderer/components/Settings/context/SettingsFormContext";
 import { useDirectoryPicker } from "@renderer/components/Settings/hooks/useDirectoryPicker";
 import { CONCURRENCY_OPTIONS } from "@renderer/components/Settings/settings.constants";
 import { IconUpload } from "@tabler/icons-react";
-import type { SettingsForm } from "@types";
 
-export function GlobalOptions({
-	form,
-}: {
-	form: UseFormReturnType<SettingsForm>;
-}) {
+export function GlobalOptions() {
+	const form = useSettingsFormContext();
 	const getOutputDirectoryPath = useDirectoryPicker();
 
 	const handleDirectoryPicker = async () => {

--- a/src/renderer/src/components/Settings/Settings.tsx
+++ b/src/renderer/src/components/Settings/Settings.tsx
@@ -21,6 +21,7 @@ import { useAppDispatch } from "@renderer/hooks/useAppDispatch";
 import { saveSettings } from "@renderer/store/slices/settingsSlice";
 import { IconSettings } from "@tabler/icons-react";
 import { AudioOptions } from "./AudioOptions/AudioOptions";
+import { SettingsFormProvider } from "./context/SettingsFormContext";
 import { GlobalOptions } from "./GlobalOptions/GlobalOptions";
 import useSettingsForm from "./hooks/useSettingsForm";
 
@@ -38,27 +39,29 @@ export default function Settings() {
 	return (
 		<>
 			<Modal opened={opened} onClose={close} title="Settings">
-				<form
-					onSubmit={form.onSubmit((values) => {
-						const newValues = {
-							audio: structuredClone(values.audio),
-							global: structuredClone(values.global),
-						};
-						dispatch(saveSettings(newValues));
-						close();
-					})}
-				>
-					<Stack>
-						<GlobalOptions form={form} />
-						<AudioOptions form={form} />
-						<Flex align={"center"} justify={"space-between"} mt={"sm"}>
-							<Button onClick={() => form.reset()}>Reset</Button>
-							<Button type="submit" bg="green" px={"xl"}>
-								Submit
-							</Button>
-						</Flex>
-					</Stack>
-				</form>
+				<SettingsFormProvider form={form}>
+					<form
+						onSubmit={form.onSubmit((values) => {
+							const newValues = {
+								audio: structuredClone(values.audio),
+								global: structuredClone(values.global),
+							};
+							dispatch(saveSettings(newValues));
+							close();
+						})}
+					>
+						<Stack>
+							<GlobalOptions />
+							<AudioOptions />
+							<Flex align={"center"} justify={"space-between"} mt={"sm"}>
+								<Button onClick={() => form.reset()}>Reset</Button>
+								<Button type="submit" bg="green" px={"xl"}>
+									Submit
+								</Button>
+							</Flex>
+						</Stack>
+					</form>
+				</SettingsFormProvider>
 			</Modal>
 			<Button leftSection={<IconSettings size={14} />} onClick={open}>
 				Settings

--- a/src/renderer/src/components/Settings/context/SettingsFormContext.ts
+++ b/src/renderer/src/components/Settings/context/SettingsFormContext.ts
@@ -15,22 +15,22 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { Box, Stack, Title } from "@mantine/core";
-import OutputExtensions from "@renderer/components/Settings/AudioOptions//OutputExtensions/OutputExtensions";
-import Filters from "@renderer/components/Settings/AudioOptions/Filters/Filters";
-import Bitrate from "./Bitrate/Bitrate";
-import Codecs from "./Codecs/Codecs";
+import { createFormContext, type UseFormReturnType } from "@mantine/form";
+import type { SettingsForm } from "@types";
+import type { FC, PropsWithChildren, ReactNode } from "react";
 
-export function AudioOptions() {
-	return (
-		<Box>
-			<Title order={3}>Audio options</Title>
-			<Stack>
-				<OutputExtensions />
-				<Filters />
-				<Codecs />
-				<Bitrate />
-			</Stack>
-		</Box>
-	);
-}
+const [Provider, useSettingsFormContext, useSettingsFormInstance] =
+	createFormContext<SettingsForm>();
+
+type SettingsFormProviderProps = PropsWithChildren<{
+	form: UseFormReturnType<SettingsForm>;
+	children: ReactNode;
+}>;
+
+const SettingsFormProvider: FC<SettingsFormProviderProps> = Provider;
+
+export {
+	SettingsFormProvider,
+	useSettingsFormContext,
+	useSettingsFormInstance,
+};

--- a/src/renderer/src/components/Settings/hooks/useSettingsForm.ts
+++ b/src/renderer/src/components/Settings/hooks/useSettingsForm.ts
@@ -15,14 +15,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { useForm } from "@mantine/form";
 import { useAppSelector } from "@renderer/hooks/useAppSelector";
-import type { SettingsForm } from "@types";
 import { useEffect } from "react";
+import { useSettingsFormInstance } from "../context/SettingsFormContext";
 
 export default function useSettingsForm() {
 	const settings = useAppSelector((state) => state.settings);
-	const form = useForm<SettingsForm>({
+	const form = useSettingsFormInstance({
 		initialValues: {
 			audio: structuredClone(settings.audio),
 			global: structuredClone(settings.global),


### PR DESCRIPTION
Create SettingsFormContext using Mantine's createFormContext to provide the form instance to all child components. This eliminates the need to pass the "form" prop through multiple layers. All settings components now consume the form via the useSettingsFormContext hook instead of receiving it as a prop.