### PR TITLE
feat(shell): add API to open output folder

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -47,4 +47,5 @@ export const INVOKE_CHANNELS = {
 	GET_OUTPUT_DIRECTORY: "getOutputDirectoryPath",
 	START_PROCESSING: "startProcessing",
 	STOP_PROCESSING: "stopProcessing",
+	OPEN_OUTPUT_FOLDER: "openOutputFolder",
 } as const;

--- a/src/main/handlers/handlers.ts
+++ b/src/main/handlers/handlers.ts
@@ -25,6 +25,7 @@ import {
 	startProcessing,
 	stopProcessing,
 } from "@main/services/processing.service";
+import { openOutputFolder } from "@main/services/shell.service";
 import { ipcMain } from "electron";
 
 export function registerIpcHandlers(): void {
@@ -36,6 +37,7 @@ export function registerIpcHandlers(): void {
 		return await parseMetadata(filePaths);
 	});
 	ipcMain.handle(INVOKE_CHANNELS.GET_OUTPUT_DIRECTORY, getOutputDirectoryPath);
+	ipcMain.handle(INVOKE_CHANNELS.OPEN_OUTPUT_FOLDER, openOutputFolder);
 
 	ipcMain.handle(INVOKE_CHANNELS.START_PROCESSING, startProcessing);
 	ipcMain.handle(INVOKE_CHANNELS.STOP_PROCESSING, stopProcessing);

--- a/src/main/services/shell.service.ts
+++ b/src/main/services/shell.service.ts
@@ -1,0 +1,29 @@
+/*
+ * sound-balance-electron
+ * Copyright (C) 2026 Pavel Alloyarov
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { shell } from "electron";
+import type { IpcMainInvokeEvent } from "electron/main";
+
+export async function openOutputFolder(
+	_: IpcMainInvokeEvent,
+	folderPath: string,
+): Promise<void> {
+	const error = await shell.openPath(folderPath);
+	if (error) {
+		throw new Error(`Failed to open folder: ${error}`);
+	}
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -45,6 +45,8 @@ const api = {
 		return () =>
 			ipcRenderer.removeAllListeners(EVENT_CHANNELS.PROCESSING_RESULT);
 	},
+	openOutputFolder: (outputDirectoryPath: string) =>
+		ipcRenderer.invoke(INVOKE_CHANNELS.OPEN_OUTPUT_FOLDER, outputDirectoryPath),
 } satisfies API;
 
 if (process.contextIsolated) {

--- a/types.ts
+++ b/types.ts
@@ -28,6 +28,7 @@ export type API = {
 	responseOnStart: (cb: (msg: string) => void) => () => void;
 	responseOnStop: (cb: (msg: StoppingStatus) => void) => () => void;
 	processingResult: (cb: (msg: ProcessingStatus) => void) => () => void;
+	openOutputFolder: (outputDirectoryPath: string) => Promise<void>;
 };
 
 export type Metadata = IAudioMetadata & {


### PR DESCRIPTION
- Add openOutputFolder IPC handle that open the specified directory in the native file explorer.
- Register the new handler in handlers.ts with channel constant.
- Expose openOutputFolder in preload API for renderer invocation.
- Update API type definition in types.