### PR TITLE
[FE-053] Add open folder

### DIFF
--- a/src/main/constants.ts
+++ b/src/main/constants.ts
@@ -21,6 +21,7 @@ import type { SettingsForm } from "@types";
 export const INITIALSETTINGS = {
 	global: {
 		outputDirectoryPath: "",
+		openOutputFolderOnComplete: false,
 		overwrite: true,
 		noOverwrite: false,
 		concurrency: 1,

--- a/src/renderer/src/components/ResultsModal/ResultsModal.tsx
+++ b/src/renderer/src/components/ResultsModal/ResultsModal.tsx
@@ -31,12 +31,21 @@ import { Fragment, useEffect } from "react";
 export default function ResultModal() {
 	const [opened, { open, close }] = useDisclosure();
 	const results = useAppSelector((state) => state.results);
+	const {
+		global: { outputDirectoryPath },
+	} = useAppSelector((state) => state.settings);
 
 	useEffect(() => {
 		if (results.total > 0) {
 			open();
 		}
 	}, [results, open]);
+
+	const handleOpenOutputFolder = () => {
+		if (outputDirectoryPath) {
+			window.api.openOutputFolder(outputDirectoryPath);
+		}
+	};
 
 	return (
 		<>
@@ -62,6 +71,11 @@ export default function ResultModal() {
 								</Accordion.Panel>
 							</Accordion.Item>
 						</Accordion>
+					)}
+					{results.total > 0 && (
+						<Button onClick={handleOpenOutputFolder} mt={"md"}>
+							Open Output Folder
+						</Button>
 					)}
 				</Stack>
 			</Modal>

--- a/src/renderer/src/components/Settings/GlobalOptions/GlobalOptions.tsx
+++ b/src/renderer/src/components/Settings/GlobalOptions/GlobalOptions.tsx
@@ -89,6 +89,22 @@ export function GlobalOptions() {
 						}}
 						{...form.getInputProps("global.noOverwrite", { type: "checkbox" })}
 					/>
+					<Divider />
+					<Switch
+						label={"Open output folder after processing completes:"}
+						labelPosition="left"
+						onLabel="yes"
+						offLabel="no"
+						size="md"
+						styles={{
+							body: {
+								justifyContent: "space-between",
+							},
+						}}
+						{...form.getInputProps("global.openOutputFolderOnComplete", {
+							type: "checkbox",
+						})}
+					/>
 				</Stack>
 			</Stack>
 		</Box>

--- a/src/renderer/src/components/StartProcessing/StartProcessing.tsx
+++ b/src/renderer/src/components/StartProcessing/StartProcessing.tsx
@@ -70,6 +70,12 @@ export default function StartProcessing() {
 			try {
 				const results = await window.api.startProcessing(data);
 				dispatch(setResults(results));
+				if (
+					settings.global.openOutputFolderOnComplete &&
+					settings.global.outputDirectoryPath
+				) {
+					window.api.openOutputFolder(settings.global.outputDirectoryPath);
+				}
 			} catch (error) {
 				setErrorMsg(
 					`An error occurred during processing: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/renderer/src/store/slices/settingsSlice.ts
+++ b/src/renderer/src/store/slices/settingsSlice.ts
@@ -27,6 +27,7 @@ const SETTINGS_ACTIONS = {
 export const initialSettings: SettingsForm = {
 	global: {
 		outputDirectoryPath: "",
+		openOutputFolderOnComplete: false,
 		overwrite: true,
 		noOverwrite: false,
 		concurrency: 1,

--- a/src/shared/types/settings.types.ts
+++ b/src/shared/types/settings.types.ts
@@ -14,6 +14,7 @@ export type SettingsForm = {
 	};
 	global: {
 		outputDirectoryPath: string;
+		openOutputFolderOnComplete: boolean;
 		concurrency: number;
 		overwrite: boolean;
 		noOverwrite: boolean;


### PR DESCRIPTION
## Summary

This PR adds two convenient ways to open the output folder after processing: a global setting to automatically open it on completion, and a manual button in the results modal. Both actions use the existing openOutputFolder IPC API to reveal the folder in the system file explorer.

## Changes

### New Features
- **Automatic folder opening after processing**  
  - Added openOutputFolderOnComplete to global settings (default: false).  
  - A toggle in the GlobalOptions UI enables the behavior.  
  - When processing succeeds and the setting is enabled, the app automatically opens the output folder.

- **Manual “Open Output Folder” button in results modal**  
  - Added a button in the Results modal that immediately opens the output directory.  
  - Provides quick access without changing any settings.
