### PR TITLE
refactor(processing): use useTracks mutation for status updates and simplify two-pass logic

### DIFF
--- a/src/main/services/processing.service.ts
+++ b/src/main/services/processing.service.ts
@@ -51,42 +51,18 @@ export const startProcessing = async (
 		INITIALSETTINGS.audio,
 		data.settings.audio,
 	);
+	const isTwoPass =
+		data.settings.audio.audioFilter === "loudnorm" &&
+		data.settings.audio.filterOptions?.linear !== false;
 
 	for (const track of data.tracks) {
 		if (!track.filePath || track.status !== "pending") continue;
 
 		queue.add(async () => {
 			if (signal.aborted) return;
-			let proc: TwoPassProcessManager | ProcessManager;
-
-			if (
-				data.settings.audio.audioFilter === "loudnorm" &&
-				data.settings.audio.filterOptions?.linear !== false
-			) {
-				proc = new TwoPassProcessManager();
-				const inputFile = track.filePath;
-				const outputFile = path.join(dirPath, track.file);
-
-				await proc.run({
-					input: inputFile,
-					output: outputFile,
-					globalSettings,
-					trackSettings,
-					filterOptions: data.settings.audio.filterOptions,
-					signal: signal,
-				});
-			} else {
-				proc = new ProcessManager();
-				const inputFile = track.filePath;
-				const outputFile = path.join(dirPath, track.file);
-				await proc.run({
-					input: inputFile,
-					output: outputFile,
-					globalSettings,
-					trackSettings,
-				});
-			}
-
+			const proc = isTwoPass
+				? new TwoPassProcessManager()
+				: new ProcessManager();
 			activeProcesses.set(track.id, proc);
 
 			try {
@@ -95,7 +71,27 @@ export const startProcessing = async (
 					status: "processing",
 				} satisfies ProcessingStatus);
 
+				const inputFile = track.filePath;
+				const outputFile = path.join(dirPath, track.file);
 				total++;
+
+				if (proc instanceof TwoPassProcessManager) {
+					await proc.run({
+						input: inputFile,
+						output: outputFile,
+						globalSettings,
+						trackSettings,
+						filterOptions: data.settings.audio.filterOptions,
+						signal: signal,
+					});
+				} else if (proc instanceof ProcessManager) {
+					await proc.run({
+						input: inputFile,
+						output: outputFile,
+						globalSettings,
+						trackSettings,
+					});
+				}
 				successful++;
 
 				event.sender.send(EVENT_CHANNELS.PROCESSING_RESULT, {

--- a/src/renderer/src/components/StartProcessing/StartProcessing.tsx
+++ b/src/renderer/src/components/StartProcessing/StartProcessing.tsx
@@ -24,7 +24,6 @@ import { useAppDispatch } from "@renderer/hooks/useAppDispatch";
 import { useAppSelector } from "@renderer/hooks/useAppSelector";
 import { useTracks } from "@renderer/hooks/useTracks";
 import { setResults } from "@renderer/store/slices/resultsSlice";
-import { updateInDB } from "@renderer/store/slices/tracksSlice";
 import type { Data } from "@types";
 import { useEffect, useState } from "react";
 import type { ProcessingStatus, StoppingStatus } from "@/types";
@@ -33,7 +32,7 @@ export default function StartProcessing() {
 	const [opened, { open, close }] = useDisclosure();
 	const [isRunning, setIsRunning] = useState(false);
 	const [errorMsg, setErrorMsg] = useState("");
-	const { selectedTracks: tracks } = useTracks();
+	const { selectedTracks: tracks, updateTrack } = useTracks();
 	const settings = useAppSelector((state) => state.settings);
 	const dispatch = useAppDispatch();
 
@@ -47,11 +46,13 @@ export default function StartProcessing() {
 	}, []);
 
 	useEffect(() => {
-		const unsubscribe = window.api.processingResult((data: ProcessingStatus) =>
-			dispatch(updateInDB({ id: data.id, changes: { status: data.status } })),
+		const unsubscribe = window.api.processingResult(
+			(data: ProcessingStatus) => {
+				updateTrack({ id: data.id, changes: { status: data.status } });
+			},
 		);
 		return () => unsubscribe();
-	}, [dispatch]);
+	}, [updateTrack]);
 
 	const sendData = async () => {
 		if (!settings.global.outputDirectoryPath) {


### PR DESCRIPTION
- Replace direct Redux dispatch thunk with the updateTrack mutation from the useTracks hook in StartProcessing.
- Move two-pass detection outside the loop to isTwoPass variable
- Use conditional to instantiate either TwoPassProcessManager or ProcessManager
- Move run call into try block after sending processing status