### PR TITLE
[FE-057] Add default values and refactor

### DIFF
--- a/src/renderer/src/components/Settings/AudioOptions/Bitrate/Bitrate.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Bitrate/Bitrate.tsx
@@ -27,6 +27,7 @@ export default function Bitrate() {
 				<Text>Choose an audio bitrate:</Text>
 				<SegmentedControl
 					data={["cbr", "vbr", "auto"]}
+					defaultValue={"auto"}
 					radius={"lg"}
 					{...form.getInputProps("audio.audioQuality")}
 				/>

--- a/src/renderer/src/components/Settings/AudioOptions/Bitrate/BitrateOptions/BitrateOptions.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Bitrate/BitrateOptions/BitrateOptions.tsx
@@ -68,6 +68,8 @@ export default function BitrateOptions() {
 		case "auto":
 			return null;
 		default:
-			return <Text>Unsupported value. Please choose "cbr" or "vbr".</Text>;
+			return (
+				<Text>Unsupported value. Please choose "cbr", "vbr" or "auto".</Text>
+			);
 	}
 }

--- a/src/renderer/src/components/Settings/AudioOptions/Codecs/CodecOptions/CodecOptions.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Codecs/CodecOptions/CodecOptions.tsx
@@ -47,6 +47,7 @@ export function CodecOptions({
 									description={field.desc}
 									min={field.min}
 									max={field.max}
+									defaultValue={field.defaultValue}
 									{...form.getInputProps(`audio.codecOptions.${field.label}`)}
 								/>
 							);
@@ -57,6 +58,7 @@ export function CodecOptions({
 									label={field.label}
 									description={field.desc}
 									data={field.options}
+									defaultValue={field.defaultValue}
 									{...form.getInputProps(`audio.codecOptions.${field.label}`)}
 								/>
 							);
@@ -69,6 +71,7 @@ export function CodecOptions({
 									onLabel="enable"
 									offLabel="disable"
 									size="md"
+									defaultValue={field.defaultValue}
 									{...form.getInputProps(`audio.codecOptions.${field.label}`, {
 										type: "checkbox",
 									})}

--- a/src/renderer/src/components/Settings/AudioOptions/Filters/FilterOptions/FilterOptions.tsx
+++ b/src/renderer/src/components/Settings/AudioOptions/Filters/FilterOptions/FilterOptions.tsx
@@ -54,6 +54,7 @@ export function AudioFilterFactory({
 								description={field.desc}
 								min={field.min}
 								max={field.max}
+								defaultValue={field.defaultValue}
 								{...form.getInputProps(`audio.filterOptions.${field.label}`)}
 							/>
 						);
@@ -64,6 +65,7 @@ export function AudioFilterFactory({
 								label={field.label}
 								description={field.desc}
 								data={field.options}
+								defaultValue={field.defaultValue}
 								{...form.getInputProps(`audio.filterOptions.${field.label}`)}
 							/>
 						);
@@ -73,6 +75,7 @@ export function AudioFilterFactory({
 								key={field.label}
 								label={field.label}
 								description={field.desc}
+								defaultValue={field.defaultValue}
 								{...form.getInputProps(`audio.filterOptions.${field.label}`)}
 							/>
 						);
@@ -85,6 +88,7 @@ export function AudioFilterFactory({
 								onLabel="enable"
 								offLabel="disable"
 								size="md"
+								defaultChecked={field.defaultValue}
 								{...form.getInputProps(`audio.filterOptions.${field.label}`, {
 									type: "checkbox",
 								})}

--- a/src/renderer/src/components/Settings/settings.constants.ts
+++ b/src/renderer/src/components/Settings/settings.constants.ts
@@ -1102,19 +1102,6 @@ export const FILTER_OPTIONS = {
 				desc: "Treat mono input files as dual-mono.",
 				defaultValue: true,
 			},
-			{
-				type: "select",
-				label: "print_format",
-				desc: "Set print format for stats.",
-				options: ["none", "summary", "json"],
-				defaultValue: "none",
-			},
-			{
-				type: "text",
-				label: "stats_file",
-				desc: "Write stats to specified file.",
-				defaultValue: "",
-			},
 		],
 	},
 	// afftdn: {

--- a/src/renderer/src/store/slices/settingsSlice.ts
+++ b/src/renderer/src/store/slices/settingsSlice.ts
@@ -34,7 +34,7 @@ export const initialSettings: SettingsForm = {
 	},
 	audio: {
 		audioCodec: "copy",
-		audioQuality: "vbr",
+		audioQuality: "auto",
 		audioQualityValue: "4",
 		audioFilter: "",
 		outputExtension: "copy",


### PR DESCRIPTION
## Changes

- **Default audio quality set to "auto"**  
  Changed the Redux settings slice’s default audioQuality from "vbr" to "auto". This aligns the client‑side initial state with both the main process’s INITIALSETTINGS and the UI’s default selection.

- **Removed unused loudnorm options**  
  Deleted the file‑output‑related options from the loudnorm filter configuration. Since the two‑pass loudnorm implementation now extracts stats from stderr, these options were dead and unnecessarily cluttered the UI.

- **Default values for option form fields**  
  Updated CodecOptions, Bitrate, and FilterOptions to pass defaultValue (or equivalent) to NumberInput, Select, TextInput, and Switch components. Each control now correctly initializes to the value specified in its option schema, preventing blank or zero‑state displays until the user interacts.
