### PR TITLE
[INFRA-017] Update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "sound-balance-electron",
 			"version": "0.1.0",
 			"hasInstallScript": true,
-			"license": "GPL-3.0-only",
+			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@electron-toolkit/preload": "^3.0.2",
 				"@electron-toolkit/utils": "^4.0.0",
@@ -16,13 +16,13 @@
 				"@mantine/form": "^9.3.1",
 				"@mantine/hooks": "^9.3.1",
 				"@reduxjs/toolkit": "^2.12.0",
-				"@tabler/icons-react": "^3.41.1",
 				"@tanstack/react-query": "^5.96.2",
 				"@tanstack/react-router": "^1.169.2",
 				"@tanstack/react-table": "^8.21.3",
 				"dexie": "^4.4.2",
 				"dexie-react-hooks": "^4.4.0",
 				"ffmpeg-static": "^5.2.0",
+				"lucide-react": "^1.22.0",
 				"music-metadata": "^11.12.3",
 				"p-queue": "^9.1.0",
 				"react-redux": "^9.2.0",
@@ -1944,32 +1944,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/@tabler/icons": {
-			"version": "3.44.0",
-			"resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
-			"integrity": "sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/codecalm"
-			}
-		},
-		"node_modules/@tabler/icons-react": {
-			"version": "3.44.0",
-			"resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.44.0.tgz",
-			"integrity": "sha512-8+rvzBbVm/1Z3sG3x7GUNAaxIKxwgz8xaMhRs23nrCnMTKRFAhEC+82zAIFeAA0seXdrAGX5HFCkaLpGK2rVHg==",
-			"license": "MIT",
-			"dependencies": {
-				"@tabler/icons": "3.44.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/codecalm"
-			},
-			"peerDependencies": {
-				"react": ">= 16"
 			}
 		},
 		"node_modules/@tanstack/history": {
@@ -7141,6 +7115,15 @@
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/lucide-react": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.22.0.tgz",
+			"integrity": "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==",
+			"license": "ISC",
+			"peerDependencies": {
+				"react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
 		"@mantine/form": "^9.3.1",
 		"@mantine/hooks": "^9.3.1",
 		"@reduxjs/toolkit": "^2.12.0",
-		"@tabler/icons-react": "^3.41.1",
 		"@tanstack/react-query": "^5.96.2",
 		"@tanstack/react-router": "^1.169.2",
 		"@tanstack/react-table": "^8.21.3",
 		"dexie": "^4.4.2",
 		"dexie-react-hooks": "^4.4.0",
 		"ffmpeg-static": "^5.2.0",
+		"lucide-react": "^1.22.0",
 		"music-metadata": "^11.12.3",
 		"p-queue": "^9.1.0",
 		"react-redux": "^9.2.0",
@@ -71,5 +71,11 @@
 		"commitizen": {
 			"path": "./node_modules/cz-conventional-changelog"
 		}
+	},
+	"allowScripts": {
+		"esbuild@0.25.12": true,
+		"electron-winstaller@5.4.0": true,
+		"ffmpeg-static@5.3.0": true,
+		"lefthook@2.1.9": true
 	}
 }

--- a/src/renderer/src/components/AddButton/AddButton.tsx
+++ b/src/renderer/src/components/AddButton/AddButton.tsx
@@ -18,7 +18,7 @@
 import { Button } from "@mantine/core";
 import { useAppSelector } from "@renderer/hooks/useAppSelector";
 import { useTracks } from "@renderer/hooks/useTracks";
-import { IconUpload } from "@tabler/icons-react";
+import { Upload } from "lucide-react";
 
 export default function AddButton() {
 	const activeCollection = useAppSelector((state) => state.activeCollection);
@@ -36,7 +36,7 @@ export default function AddButton() {
 	};
 
 	return (
-		<Button leftSection={<IconUpload size={14} />} onClick={loadFiles}>
+		<Button leftSection={<Upload size={14} />} onClick={loadFiles}>
 			Add
 		</Button>
 	);

--- a/src/renderer/src/components/Collections/components/AddCollection/AddCollection.tsx
+++ b/src/renderer/src/components/Collections/components/AddCollection/AddCollection.tsx
@@ -27,7 +27,7 @@ import {
 import { schemaResolver, useForm } from "@mantine/form";
 import { useDisclosure } from "@mantine/hooks";
 import { useCollections } from "@renderer/components/Collections/hooks/useCollections";
-import { IconPlusFilled } from "@tabler/icons-react";
+import { Plus } from "lucide-react";
 import z from "zod";
 import type { CollectionType } from "@/types";
 
@@ -80,7 +80,7 @@ export default function AddCollection() {
 					onClick={open}
 					my="sm"
 				>
-					<IconPlusFilled />
+					<Plus />
 				</ActionIcon>
 			</Tooltip>
 		</>

--- a/src/renderer/src/components/Collections/components/DeleteCollection/DeleteCollection.tsx
+++ b/src/renderer/src/components/Collections/components/DeleteCollection/DeleteCollection.tsx
@@ -32,7 +32,7 @@ import { useCollections } from "@renderer/components/Collections/hooks/useCollec
 import { useAppDispatch } from "@renderer/hooks/useAppDispatch";
 import { useAppSelector } from "@renderer/hooks/useAppSelector";
 import { setActiveCollection } from "@renderer/store/slices/collectionSlice";
-import { IconAlertTriangleFilled, IconTrash } from "@tabler/icons-react";
+import { Trash2, TriangleAlert } from "lucide-react";
 
 export default function DeleteCollection() {
 	const [opened, { open, close }] = useDisclosure(false);
@@ -69,7 +69,7 @@ export default function DeleteCollection() {
 					</Modal.Header>
 					<Modal.Body>
 						<Stack align="center">
-							<IconAlertTriangleFilled size={48} color="red" />
+							<TriangleAlert size={48} color="red" />
 							<Title order={2}>Delete collection</Title>
 							<Flex justify={"center"}>
 								<Text
@@ -109,7 +109,7 @@ export default function DeleteCollection() {
 					onClick={open}
 					ms="sm"
 				>
-					<IconTrash />
+					<Trash2 />
 				</ActionIcon>
 			</Tooltip>
 		</>

--- a/src/renderer/src/components/Collections/components/EditCollectionTitle/EditCollectionTitle.tsx
+++ b/src/renderer/src/components/Collections/components/EditCollectionTitle/EditCollectionTitle.tsx
@@ -30,7 +30,7 @@ import { useCollections } from "@renderer/components/Collections/hooks/useCollec
 import { useAppDispatch } from "@renderer/hooks/useAppDispatch";
 import { useAppSelector } from "@renderer/hooks/useAppSelector";
 import { setActiveCollection } from "@renderer/store/slices/collectionSlice";
-import { IconEdit } from "@tabler/icons-react";
+import { Edit } from "lucide-react";
 import z from "zod";
 
 const collectionTitleSchema = z.object({
@@ -103,7 +103,7 @@ export default function EditCollectionTitle() {
 					onClick={handleOpen}
 					ms="sm"
 				>
-					<IconEdit />
+					<Edit />
 				</ActionIcon>
 			</Tooltip>
 		</>

--- a/src/renderer/src/components/DeleteButton/DeleteButton.tsx
+++ b/src/renderer/src/components/DeleteButton/DeleteButton.tsx
@@ -17,7 +17,7 @@
  */
 import { Button, useMantineTheme } from "@mantine/core";
 import { useTracks } from "@renderer/hooks/useTracks";
-import { IconTrash } from "@tabler/icons-react";
+import { Trash2 } from "lucide-react";
 
 export default function DeleteButton() {
 	const theme = useMantineTheme();
@@ -29,7 +29,7 @@ export default function DeleteButton() {
 
 	return (
 		<Button
-			leftSection={<IconTrash size={14} />}
+			leftSection={<Trash2 size={14} />}
 			color={theme.colors.red[8]}
 			// disabled={selectedTracksIds.length === 0}
 			onClick={deleteSelectedTracks}

--- a/src/renderer/src/components/ErrorModal/ErrorModal.tsx
+++ b/src/renderer/src/components/ErrorModal/ErrorModal.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Flex, Modal, type ModalRootProps, Text } from "@mantine/core";
-import { IconAlertHexagon } from "@tabler/icons-react";
+import { AlertOctagon } from "lucide-react";
 
 type ErrorModal = {
 	message: string;
@@ -36,7 +36,7 @@ export default function ErrorModal({
 			onClose={onClose}
 			title={
 				<Flex gap={"xs"}>
-					<IconAlertHexagon color="red" />
+					<AlertOctagon color="red" />
 					<Text>{title}</Text>
 				</Flex>
 			}

--- a/src/renderer/src/components/FilterSelect/FilterSelect.tsx
+++ b/src/renderer/src/components/FilterSelect/FilterSelect.tsx
@@ -16,8 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { ActionIcon, Popover, Select } from "@mantine/core";
-import { IconFilter } from "@tabler/icons-react";
 import type { Column } from "@tanstack/react-table";
+import { Funnel } from "lucide-react";
 import { useMemo } from "react";
 import type { Metadata } from "@/types";
 
@@ -42,7 +42,7 @@ export default function FilterSelect({
 		<Popover shadow="lg" trapFocus>
 			<Popover.Target>
 				<ActionIcon variant="subtle" aria-label="Filter" color="dark">
-					<IconFilter size={16} />
+					<Funnel size={16} />
 				</ActionIcon>
 			</Popover.Target>
 			<Popover.Dropdown>

--- a/src/renderer/src/components/InfoModal/InfoModal.tsx
+++ b/src/renderer/src/components/InfoModal/InfoModal.tsx
@@ -17,7 +17,7 @@
  */
 import { Button, Image, Modal, Table } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { IconCaretRight } from "@tabler/icons-react";
+import { ChevronRight } from "lucide-react";
 import type { Metadata } from "@/types";
 
 export type InfoModalProps = {
@@ -28,7 +28,7 @@ export default function InfoModal({ trackData }: InfoModalProps) {
 	const [opened, { open, close }] = useDisclosure(false);
 	return (
 		<>
-			<Button rightSection={<IconCaretRight />} onClick={open}>
+			<Button rightSection={<ChevronRight />} onClick={open}>
 				Details
 			</Button>
 			<Modal.Root opened={opened} onClose={close}>

--- a/src/renderer/src/components/RunButton/RunButton.tsx
+++ b/src/renderer/src/components/RunButton/RunButton.tsx
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Button } from "@mantine/core";
-import { IconPlayerPlayFilled, IconPlayerStop } from "@tabler/icons-react";
+import { Play, Square } from "lucide-react";
 
 type RunButtonProps = {
 	isRunning: boolean;
@@ -29,19 +29,13 @@ export default function RunButton({
 }: RunButtonProps) {
 	if (isRunning) {
 		return (
-			<Button
-				leftSection={<IconPlayerStop size={14} />}
-				onClick={handleButtonClick}
-			>
+			<Button leftSection={<Square size={14} />} onClick={handleButtonClick}>
 				Stop
 			</Button>
 		);
 	}
 	return (
-		<Button
-			leftSection={<IconPlayerPlayFilled size={14} />}
-			onClick={handleButtonClick}
-		>
+		<Button leftSection={<Play size={14} />} onClick={handleButtonClick}>
 			Run
 		</Button>
 	);

--- a/src/renderer/src/components/Settings/GlobalOptions/GlobalOptions.tsx
+++ b/src/renderer/src/components/Settings/GlobalOptions/GlobalOptions.tsx
@@ -27,7 +27,7 @@ import {
 import { useSettingsFormContext } from "@renderer/components/Settings/context/SettingsFormContext";
 import { useDirectoryPicker } from "@renderer/components/Settings/hooks/useDirectoryPicker";
 import { CONCURRENCY_OPTIONS } from "@renderer/components/Settings/settings.constants";
-import { IconUpload } from "@tabler/icons-react";
+import { Upload } from "lucide-react";
 
 export function GlobalOptions() {
 	const form = useSettingsFormContext();
@@ -46,7 +46,7 @@ export function GlobalOptions() {
 			<Stack>
 				<TextInput
 					label={"Output directory:"}
-					rightSection={<IconUpload onClick={handleDirectoryPicker} />}
+					rightSection={<Upload onClick={handleDirectoryPicker} />}
 					{...form.getInputProps("global.outputDirectoryPath")}
 				/>
 				<Stack>

--- a/src/renderer/src/components/Settings/Settings.tsx
+++ b/src/renderer/src/components/Settings/Settings.tsx
@@ -19,7 +19,7 @@ import { Button, Flex, Loader, Modal, Stack } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { useAppDispatch } from "@renderer/hooks/useAppDispatch";
 import { saveSettings } from "@renderer/store/slices/settingsSlice";
-import { IconSettings } from "@tabler/icons-react";
+import { Settings as IconSettings } from "lucide-react";
 import { AudioOptions } from "./AudioOptions/AudioOptions";
 import { SettingsFormProvider } from "./context/SettingsFormContext";
 import { GlobalOptions } from "./GlobalOptions/GlobalOptions";

--- a/src/renderer/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/renderer/src/components/StatusIcon/StatusIcon.tsx
@@ -16,12 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { Loader, Tooltip, useMantineTheme } from "@mantine/core";
-import {
-	IconCircleCheck,
-	IconCircleX,
-	IconClock,
-	IconExclamationCircle,
-} from "@tabler/icons-react";
+import { CircleAlert, CircleCheck, CircleX, Clock } from "lucide-react";
 import type { Metadata } from "@/types";
 
 type Status = Pick<Metadata, "status">;
@@ -33,7 +28,7 @@ export default function StatusIcon({ status }: Status) {
 		case "pending": {
 			return (
 				<Tooltip label="Pending">
-					<IconClock stroke={2} color={theme.colors.blue[6]} />
+					<Clock color={theme.colors.blue[6]} />
 				</Tooltip>
 			);
 		}
@@ -47,21 +42,21 @@ export default function StatusIcon({ status }: Status) {
 		case "completed": {
 			return (
 				<Tooltip label="Completed">
-					<IconCircleCheck stroke={2} color={theme.colors.green[6]} />
+					<CircleCheck color={theme.colors.green[6]} />
 				</Tooltip>
 			);
 		}
 		case "failed": {
 			return (
 				<Tooltip label="Failed">
-					<IconCircleX stroke={2} color={theme.colors.red[8]} />
+					<CircleX color={theme.colors.red[8]} />
 				</Tooltip>
 			);
 		}
 		default: {
 			return (
 				<Tooltip label="Status unknown">
-					<IconExclamationCircle stroke={2} color={theme.colors.red[8]} />
+					<CircleAlert color={theme.colors.red[8]} />
 				</Tooltip>
 			);
 		}

--- a/src/renderer/src/components/Table/Table.tsx
+++ b/src/renderer/src/components/Table/Table.tsx
@@ -33,7 +33,6 @@ import { useAppSelector } from "@renderer/hooks/useAppSelector";
 import { useTracks } from "@renderer/hooks/useTracks";
 import { setAllSelectedTracks } from "@renderer/store/slices/selectedTracksSlice";
 import { getSortingIcon } from "@renderer/utils/getSortingIcons";
-import { IconSearch } from "@tabler/icons-react";
 import {
 	type ColumnDef,
 	flexRender,
@@ -48,6 +47,7 @@ import {
 	useReactTable,
 	type VisibilityState,
 } from "@tanstack/react-table";
+import { Search } from "lucide-react";
 import { type ChangeEvent, useMemo, useState } from "react";
 import type { Metadata } from "@/types";
 
@@ -216,7 +216,7 @@ export default function TableComponent() {
 				<TextInput
 					label="Search:"
 					placeholder="Search all columns..."
-					leftSection={<IconSearch size={16} />}
+					leftSection={<Search size={16} />}
 					value={globalFilter}
 					onChange={handleGlobalFilterChange}
 				/>

--- a/src/renderer/src/utils/getSortingIcons.tsx
+++ b/src/renderer/src/utils/getSortingIcons.tsx
@@ -16,12 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 import { ActionIcon } from "@mantine/core";
-import {
-	IconArrowsSort,
-	IconSortAscending,
-	IconSortDescending,
-} from "@tabler/icons-react";
 import type { Column } from "@tanstack/react-table";
+import { ArrowDown, ArrowDownUp, ArrowUp } from "lucide-react";
 import type { Metadata } from "@/types";
 
 export function getSortingIcon(column: Column<Metadata>) {
@@ -37,7 +33,7 @@ export function getSortingIcon(column: Column<Metadata>) {
 				color="dark"
 				aria-label={`Sort ${header} in ascending order`}
 			>
-				<IconSortAscending size={16} />
+				<ArrowUp size={16} />
 			</ActionIcon>
 		);
 	} else if (dir === "desc") {
@@ -47,7 +43,7 @@ export function getSortingIcon(column: Column<Metadata>) {
 				color="dark"
 				aria-label={`Sort ${header} in descending order`}
 			>
-				<IconSortDescending size={16} />
+				<ArrowDown size={16} />
 			</ActionIcon>
 		);
 	} else {
@@ -57,7 +53,7 @@ export function getSortingIcon(column: Column<Metadata>) {
 				color="dark"
 				aria-label={`Default ${header} Sorting`}
 			>
-				<IconArrowsSort size={16} />
+				<ArrowDownUp size={16} />
 			</ActionIcon>
 		);
 	}


### PR DESCRIPTION
## Summary

This PR replaces the Tabler Icons library with Lucide React. All icon imports across components have been updated to use Lucide, ensuring a consistent and maintained icon set without visual regressions.

## Changes

- **Dependency swap**  
  Removed tabler/icons-react and added lucide-react as the new icon library.

- **Import updates**  
  Updated every icon import in the application to the equivalent Lucide React component, e.g. IconTrash → Trash2, etc.