### PR TITLE
refactor(dialog): allow selection of any files

### DIFF
--- a/src/main/services/dialogs.service.ts
+++ b/src/main/services/dialogs.service.ts
@@ -21,7 +21,6 @@ export const showDialog = async () => {
 	const { canceled, filePaths } = await dialog.showOpenDialog({
 		properties: ["multiSelections"],
 		title: "Select files",
-		filters: [{ name: "Music", extensions: ["mp3"] }],
 	});
 	return canceled ? [] : filePaths;
 };


### PR DESCRIPTION
Remove the file extension filter from the file selection dialog so that users can now select any file type instead of being limited to MP3 files only.