### PR TITLE
[QA-002] Preload tests

### DIFF
--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
-import { INVOKE_CHANNELS } from "@main/constants";
+import { EVENT_CHANNELS, INVOKE_CHANNELS } from "@main/constants";
 import { contextBridge, ipcRenderer } from "electron";
 
 vi.mock("electron", () => ({
@@ -61,9 +61,8 @@ describe("preload", () => {
 	});
 
 	describe("api object structure", () => {
-		it("exposes exactly 8 methods", () => {
-			const keys = Object.keys(api).sort();
-			expect(keys).toEqual([
+		it("exposes exactly the expected 8 methods", () => {
+			expect(Object.keys(api).sort()).toEqual([
 				"getOutputDirectoryPath",
 				"openOutputFolder",
 				"processingResult",
@@ -74,159 +73,170 @@ describe("preload", () => {
 				"stopProcessing",
 			]);
 		});
-
-		it("all exposed values are functions", () => {
-			for (const value of Object.values(api)) {
-				expect(typeof value).toBe("function");
-			}
-		});
-
-		it("does not expose non-function values", () => {
-			const values = Object.values(api);
-			expect(values.every((i) => typeof i === "function")).toBe(true);
-		});
 	});
 
-	describe("api.showDialog", () => {
-		it("invokes ipcRenderer with SHOW_DIALOG channel", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
+	describe("IPC Invoke routing", () => {
+		beforeEach(() => {
+			vi.mocked(ipcRenderer.invoke).mockReset();
+		});
+
+		it("showDialog routes to SHOW_DIALOG and resolves", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValue([]);
 			await api.showDialog();
 			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
 				INVOKE_CHANNELS.SHOW_DIALOG,
 			);
 		});
 
-		it("invokes exactly once per call", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
-			await api.showDialog();
-			expect(ipcRenderer.invoke).toHaveBeenCalledTimes(1);
-		});
-
-		it("passes only the channel argument (no extras)", async () => {
-			const mockedIPC = vi.mocked(ipcRenderer.invoke);
-			mockedIPC.mockResolvedValueOnce([]);
-			await api.showDialog();
-			expect(mockedIPC.mock.calls[0]).toHaveLength(1);
-		});
-
-		it("returns the value from ipcRenderer.invoke", async () => {
-			const result = [{ id: "1" }, { id: "2" }];
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(result as any);
-			expect(await api.showDialog()).toEqual(result);
-		});
-
-		it("returns empty array when invoke resolves with []", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
-			expect(await api.showDialog()).toEqual([]);
-		});
-
-		it("returns undefined when invoke resolves with undefined", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(undefined);
-			expect(await api.showDialog()).toBeUndefined();
-		});
-
-		it("returns null when invoke resolves with null", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(null);
-			expect(await api.showDialog()).toBeNull();
-		});
-
-		it("propagates Error rejection from ipcRenderer.invoke", async () => {
-			const error = new Error("IPC failed");
-			vi.mocked(ipcRenderer.invoke).mockRejectedValue(error);
-			await expect(api.showDialog()).rejects.toThrow(error);
-		});
-
-		it("propagates non-Error rejection from ipcRenderer.invoke", async () => {
-			const error = "string error";
-			vi.mocked(ipcRenderer.invoke).mockRejectedValue(error);
-			await expect(api.showDialog()).rejects.toBe(error);
-		});
-
-		it("propagates null rejection", async () => {
-			vi.mocked(ipcRenderer.invoke).mockRejectedValue(null);
-			await expect(api.showDialog()).rejects.toBe(null);
-		});
-
-		it("can be called multiple times in sequence", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
-			await api.showDialog();
-			await api.showDialog();
-			await api.showDialog();
-			expect(ipcRenderer.invoke).toHaveBeenCalledTimes(3);
-		});
-
-		it("works when destructured from api object", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
-			const { showDialog } = api;
-			await showDialog();
-			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
-				INVOKE_CHANNELS.SHOW_DIALOG,
-			);
-		});
-	});
-
-	describe("api.getOutputDirectoryPath", () => {
-		it("invokes ipcRenderer with GET_OUTPUT_DIRECTORY channel", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce({} as any);
-			await api.getOutputDirectoryPath();
-			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
-				INVOKE_CHANNELS.GET_OUTPUT_DIRECTORY,
-			);
-		});
-
-		it("invokes exactly once per call", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce({} as any);
-			await api.getOutputDirectoryPath();
-			expect(ipcRenderer.invoke).toHaveBeenCalledTimes(1);
-		});
-
-		it("passes only the channel argument", async () => {
-			const mockedIPC = vi.mocked(ipcRenderer.invoke);
-			mockedIPC.mockResolvedValueOnce({} as any);
-			await api.getOutputDirectoryPath();
-			expect(mockedIPC.mock.calls[0]).toHaveLength(1);
-		});
-
-		it("returns the OpenDialogReturnValue from invoke", async () => {
-			const result = { canceled: false, filePaths: ["/music"] };
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(result as any);
-			expect(await api.getOutputDirectoryPath()).toEqual(result);
-		});
-
-		it("returns canceled result from invoke", async () => {
-			const result = { canceled: true, filePaths: [] };
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(result as any);
-			expect(await api.getOutputDirectoryPath()).toEqual(result);
-		});
-
-		it("returns result with multiple filePaths", async () => {
-			const result = {
+		it("getOutputDirectoryPath routes to GET_OUTPUT_DIRECTORY", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValue({
 				canceled: false,
-				filePaths: ["/music/dir1", "/music/dir2"],
-			};
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(result as any);
-			expect(await api.getOutputDirectoryPath()).toEqual(result);
-		});
-
-		it("propagates rejection", async () => {
-			const error = new Error("fail");
-			vi.mocked(ipcRenderer.invoke).mockRejectedValue(error);
-			await expect(api.getOutputDirectoryPath()).rejects.toThrow(error);
-		});
-
-		it("propagates non-Error rejection", async () => {
-			const error = "string error";
-			vi.mocked(ipcRenderer.invoke).mockRejectedValue(error);
-			await expect(api.getOutputDirectoryPath()).rejects.toBe(error);
-		});
-
-		it("works when destructured", async () => {
-			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce({} as any);
-			const { getOutputDirectoryPath } = api;
-			await getOutputDirectoryPath();
+				filePaths: [],
+			});
+			await api.getOutputDirectoryPath();
 			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
 				INVOKE_CHANNELS.GET_OUTPUT_DIRECTORY,
 			);
+		});
+
+		it("startProcessing routes to START_PROCESSING and forwards data payload", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValue({
+				total: 0,
+				successful: 0,
+				failed: [],
+			});
+			const data = { tracks: [], settings: {} };
+			await api.startProcessing(data);
+			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+				INVOKE_CHANNELS.START_PROCESSING,
+				data,
+			);
+		});
+
+		it("stopProcessing routes to STOP_PROCESSING", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValue(undefined);
+			await api.stopProcessing();
+			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+				INVOKE_CHANNELS.STOP_PROCESSING,
+			);
+		});
+
+		it("openOutputFolder routes to OPEN_OUTPUT_FOLDER and forwards path", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValue({
+				success: true,
+				reason: "",
+			});
+			const path = "/output";
+			await api.openOutputFolder(path);
+			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+				INVOKE_CHANNELS.OPEN_OUTPUT_FOLDER,
+				path,
+			);
+		});
+
+		it("propagates rejections from ipcRenderer.invoke", async () => {
+			vi.mocked(ipcRenderer.invoke).mockRejectedValue(new Error("IPC failed"));
+			await expect(api.showDialog()).rejects.toThrow("IPC failed");
+		});
+	});
+
+	describe("IPC Event routing", () => {
+		describe("responseOnStart mechanics", () => {
+			it("registers on RESPONSE_ON_START, strips event, passes payload to callback", () => {
+				const cb = vi.fn();
+				api.responseOnStart(cb);
+				expect(ipcRenderer.on).toHaveBeenCalledWith(
+					EVENT_CHANNELS.RESPONSE_ON_START,
+					expect.any(Function),
+				);
+
+				const handler = vi.mocked(ipcRenderer.on).mock.calls[0][1];
+				const mockEvent = { sender: {} };
+				const mockMsg = "started";
+
+				handler(mockEvent as any, mockMsg);
+				expect(cb).toHaveBeenCalledWith(mockMsg);
+				expect(cb).not.toHaveBeenCalledWith(mockEvent, mockMsg);
+			});
+
+			it("returns a cleanup function that removes the specific channel listener", () => {
+				const cleanup = api.responseOnStart(vi.fn());
+				expect(typeof cleanup).toBe("function");
+
+				cleanup();
+				expect(ipcRenderer.removeAllListeners).toHaveBeenCalledWith(
+					EVENT_CHANNELS.RESPONSE_ON_START,
+				);
+			});
+		});
+
+		it("responseOnStop registers on RESPONSE_ON_STOP", () => {
+			api.responseOnStop(vi.fn());
+			expect(ipcRenderer.on).toHaveBeenCalledWith(
+				EVENT_CHANNELS.RESPONSE_ON_STOP,
+				expect.any(Function),
+			);
+		});
+
+		it("processingResult registers on PROCESSING_RESULT", () => {
+			api.processingResult(vi.fn());
+			expect(ipcRenderer.on).toHaveBeenCalledWith(
+				EVENT_CHANNELS.PROCESSING_RESULT,
+				expect.any(Function),
+			);
+		});
+	});
+
+	describe("contextBridge exposure (contextIsolated = true)", () => {
+		it("calls exposeInMainWorld with 'api' key and the api object", () => {
+			expect(exposeCalls).toHaveLength(1);
+			expect(exposeCalls[0][0]).toBe("api");
+			expect(exposeCalls[0][1]).toBe(api);
+		});
+
+		it("wraps contextBridge errors with 'Preload script failed:'", async () => {
+			vi.resetModules();
+			vi.mocked(contextBridge.exposeInMainWorld).mockImplementationOnce(() => {
+				throw new Error("Bridge error");
+			});
+			await expect(import("./index")).rejects.toThrow(
+				"Preload script failed: Bridge error",
+			);
+		});
+	});
+
+	describe("non-contextIsolated branch", () => {
+		let originalWindow: any;
+
+		beforeEach(async () => {
+			vi.resetModules();
+			originalWindow = (global as any).window;
+			(global as any).window = {};
+			Object.defineProperty(process, "contextIsolated", {
+				value: false,
+				configurable: true,
+			});
+		});
+
+		afterEach(() => {
+			if (originalWindow === undefined) delete (global as any).window;
+			else (global as any).window = originalWindow;
+			Object.defineProperty(process, "contextIsolated", {
+				value: true,
+				configurable: true,
+			});
+		});
+
+		it("assigns electronAPI and api to global window object", async () => {
+			await import("./index");
+			expect((global as any).window.electron).toEqual({ _isElectronAPI: true });
+			expect((global as any).window.api).toBeTypeOf("object");
+			expect((global as any).window.api.showDialog).toBeTypeOf("function");
+		});
+
+		it("does not call contextBridge.exposeInMainWorld", async () => {
+			await import("./index");
+			expect(contextBridge.exposeInMainWorld).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -1,0 +1,232 @@
+/*
+ * sound-balance-electron
+ * Copyright (C) 2026 Pavel Alloyarov
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+import { INVOKE_CHANNELS } from "@main/constants";
+import { contextBridge, ipcRenderer } from "electron";
+
+vi.mock("electron", () => ({
+	contextBridge: { exposeInMainWorld: vi.fn() },
+	dialog: { showOpenDialog: vi.fn() },
+	shell: { openPath: vi.fn() },
+	ipcMain: { handle: vi.fn(), on: vi.fn() },
+	ipcRenderer: {
+		invoke: vi.fn(),
+		on: vi.fn(),
+		removeAllListeners: vi.fn(),
+	},
+}));
+
+vi.mock("@electron-toolkit/preload", () => ({
+	electronAPI: { _isElectronAPI: true },
+}));
+
+describe("preload", () => {
+	let api: Record<string, (...args: any[]) => any>;
+	let exposeCalls: any[][];
+
+	beforeAll(async () => {
+		Object.defineProperty(process, "contextIsolated", {
+			value: true,
+			configurable: true,
+		});
+		await import("./index");
+		const mock = vi.mocked(contextBridge.exposeInMainWorld);
+		exposeCalls = [...mock.mock.calls];
+		api = mock.mock.calls.find((c) => c[0] === "api")?.[1];
+	});
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+	});
+
+	afterAll(() => {
+		Object.defineProperty(process, "contextIsolated", {
+			value: undefined,
+			configurable: true,
+		});
+	});
+
+	describe("api object structure", () => {
+		it("exposes exactly 8 methods", () => {
+			const keys = Object.keys(api).sort();
+			expect(keys).toEqual([
+				"getOutputDirectoryPath",
+				"openOutputFolder",
+				"processingResult",
+				"responseOnStart",
+				"responseOnStop",
+				"showDialog",
+				"startProcessing",
+				"stopProcessing",
+			]);
+		});
+
+		it("all exposed values are functions", () => {
+			for (const value of Object.values(api)) {
+				expect(typeof value).toBe("function");
+			}
+		});
+
+		it("does not expose non-function values", () => {
+			const values = Object.values(api);
+			expect(values.every((i) => typeof i === "function")).toBe(true);
+		});
+	});
+
+	describe("api.showDialog", () => {
+		it("invokes ipcRenderer with SHOW_DIALOG channel", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
+			await api.showDialog();
+			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+				INVOKE_CHANNELS.SHOW_DIALOG,
+			);
+		});
+
+		it("invokes exactly once per call", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
+			await api.showDialog();
+			expect(ipcRenderer.invoke).toHaveBeenCalledTimes(1);
+		});
+
+		it("passes only the channel argument (no extras)", async () => {
+			const mockedIPC = vi.mocked(ipcRenderer.invoke);
+			mockedIPC.mockResolvedValueOnce([]);
+			await api.showDialog();
+			expect(mockedIPC.mock.calls[0]).toHaveLength(1);
+		});
+
+		it("returns the value from ipcRenderer.invoke", async () => {
+			const result = [{ id: "1" }, { id: "2" }];
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(result as any);
+			expect(await api.showDialog()).toEqual(result);
+		});
+
+		it("returns empty array when invoke resolves with []", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
+			expect(await api.showDialog()).toEqual([]);
+		});
+
+		it("returns undefined when invoke resolves with undefined", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(undefined);
+			expect(await api.showDialog()).toBeUndefined();
+		});
+
+		it("returns null when invoke resolves with null", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(null);
+			expect(await api.showDialog()).toBeNull();
+		});
+
+		it("propagates Error rejection from ipcRenderer.invoke", async () => {
+			const error = new Error("IPC failed");
+			vi.mocked(ipcRenderer.invoke).mockRejectedValue(error);
+			await expect(api.showDialog()).rejects.toThrow(error);
+		});
+
+		it("propagates non-Error rejection from ipcRenderer.invoke", async () => {
+			const error = "string error";
+			vi.mocked(ipcRenderer.invoke).mockRejectedValue(error);
+			await expect(api.showDialog()).rejects.toBe(error);
+		});
+
+		it("propagates null rejection", async () => {
+			vi.mocked(ipcRenderer.invoke).mockRejectedValue(null);
+			await expect(api.showDialog()).rejects.toBe(null);
+		});
+
+		it("can be called multiple times in sequence", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
+			await api.showDialog();
+			await api.showDialog();
+			await api.showDialog();
+			expect(ipcRenderer.invoke).toHaveBeenCalledTimes(3);
+		});
+
+		it("works when destructured from api object", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce([]);
+			const { showDialog } = api;
+			await showDialog();
+			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+				INVOKE_CHANNELS.SHOW_DIALOG,
+			);
+		});
+	});
+
+	describe("api.getOutputDirectoryPath", () => {
+		it("invokes ipcRenderer with GET_OUTPUT_DIRECTORY channel", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce({} as any);
+			await api.getOutputDirectoryPath();
+			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+				INVOKE_CHANNELS.GET_OUTPUT_DIRECTORY,
+			);
+		});
+
+		it("invokes exactly once per call", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce({} as any);
+			await api.getOutputDirectoryPath();
+			expect(ipcRenderer.invoke).toHaveBeenCalledTimes(1);
+		});
+
+		it("passes only the channel argument", async () => {
+			const mockedIPC = vi.mocked(ipcRenderer.invoke);
+			mockedIPC.mockResolvedValueOnce({} as any);
+			await api.getOutputDirectoryPath();
+			expect(mockedIPC.mock.calls[0]).toHaveLength(1);
+		});
+
+		it("returns the OpenDialogReturnValue from invoke", async () => {
+			const result = { canceled: false, filePaths: ["/music"] };
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(result as any);
+			expect(await api.getOutputDirectoryPath()).toEqual(result);
+		});
+
+		it("returns canceled result from invoke", async () => {
+			const result = { canceled: true, filePaths: [] };
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(result as any);
+			expect(await api.getOutputDirectoryPath()).toEqual(result);
+		});
+
+		it("returns result with multiple filePaths", async () => {
+			const result = {
+				canceled: false,
+				filePaths: ["/music/dir1", "/music/dir2"],
+			};
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce(result as any);
+			expect(await api.getOutputDirectoryPath()).toEqual(result);
+		});
+
+		it("propagates rejection", async () => {
+			const error = new Error("fail");
+			vi.mocked(ipcRenderer.invoke).mockRejectedValue(error);
+			await expect(api.getOutputDirectoryPath()).rejects.toThrow(error);
+		});
+
+		it("propagates non-Error rejection", async () => {
+			const error = "string error";
+			vi.mocked(ipcRenderer.invoke).mockRejectedValue(error);
+			await expect(api.getOutputDirectoryPath()).rejects.toBe(error);
+		});
+
+		it("works when destructured", async () => {
+			vi.mocked(ipcRenderer.invoke).mockResolvedValueOnce({} as any);
+			const { getOutputDirectoryPath } = api;
+			await getOutputDirectoryPath();
+			expect(ipcRenderer.invoke).toHaveBeenCalledWith(
+				INVOKE_CHANNELS.GET_OUTPUT_DIRECTORY,
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

This PR adds a comprehensive unit test suite for the preload script. The tests verify that the context bridge exposes the correct API surface, that IPC invoke calls are routed to the proper channels, that event listeners are registered and cleaned up correctly, and that errors are propagated as expected. Both isolated and non‑isolated context scenarios are covered.

## Changes

### Tests
- **API object structure** – Confirms that the exposed API contains all 8 expected methods (showDialog, getOutputDirectoryPath, startProcessing, stopProcessing, openOutputFolder, responseOnStart, responseOnStop, processingResult).

- **IPC invoke routing** – Validates that each API method invokes the corresponding IPC channel with the correct arguments and returns the result. Tests cover success, argument forwarding, and error propagation from ipcRenderer.invoke.

- **Event listener management** – For responseOnStart, responseOnStop, and processingResult, verifies that ipcRenderer.on is called with the right channel and that the returned function unsubscribes the listener (calls the stripping callback).

- **Context bridge behavior**  
  - When contextIsolation is true, the API is exposed via contextBridge.exposeInMainWorld.  
  - When contextIsolation is false, the API is assigned directly to window.

- **Edge cases and error handling** – Ensures that errors thrown by ipcRenderer.invoke are propagated to the caller without being swallowed.

## Testing
- All new preload unit tests pass.
- The test suite uses mocked electron modules and validates both successful and failing IPC interactions.